### PR TITLE
Made the site look better on mobile, take 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,12 @@ body {
 	padding-bottom: 15px
 }
 
+@media (max-width: 1920px) {
+	#banner {
+		width: 100vw;
+	}
+}
+
 #heading {
 	text-align:center;
 	font-size:50px;
@@ -66,6 +72,10 @@ body {
 #middle {
 }
 
+#conference-photo {
+	width: 100%;
+}
+
 li {
 	margin: 3px;
 }
@@ -73,18 +83,31 @@ li {
 h2 {
 	background-image: url("sky.jpg");
 	background-repeat: no-repeat;
-	background-size: 1920px 85px;
 	padding-top: 20px;
 	padding-bottom: 20px;
-	margin-left: -350px;
-	padding-left: 350px;
 	margin-bottom: 25px;
-	width: 1920px;
 	font-size: 30px;
 }
 
+
+@media only screen and (max-width: 1200px){
+  h2 {
+		background-size: 100% 100%;
+		padding-left: 25px;
+  }
+}
+
+@media only screen and (min-width: 1200px) {
+	h2 {
+		background-size: 1920px 85px;
+		margin-left: -350px;
+		padding-left: 350px;
+		width: 1920px;
+	}
+}
+
 div.people>div>img {
-	width:170px;
+	width:168px;
 	height:200px;
     object-fit: cover;
 }
@@ -100,8 +123,9 @@ div.people {
 	margin-bottom:-15px;
 }
 
-#sponsors>a>img {
+#sponsors>center>a>img {
 	height:100px;
+	max-width: 100%;
 }
 
 @media only screen and (max-width: 1200px) {
@@ -133,8 +157,13 @@ div.people {
 
 #schedule {
   border-collapse: collapse;
-  margin-bottom: 30px;
   font-size: 11px;
+}
+
+#schedule-div {
+	padding: 2px;
+	margin-bottom: 30px;
+	overflow-x: auto;
 }
 
 td.distinguished {
@@ -254,7 +283,8 @@ industry showcase event.</p>
 </table>
 </p>
 
-<p><table id="schedule">
+<div id="schedule-div">
+  <table id="schedule">
     <thead>
       <tr>
         <th>Time (BST)</th>
@@ -434,11 +464,11 @@ industry showcase event.</p>
       </tr>
     </tbody>
   </table>
-</p>
+</div>
 
 <h2>Conference Photo</h2>
 
-<a href="conference_photo_original.png"><img style="width:1200px" src="conference_photo_webpage.jpg"/></a>
+<a href="conference_photo_original.png"><img id="conference-photo" src="conference_photo_webpage.jpg"/></a>
 
 <p>Left-to-right (with a front-to-back sublist): Tomas Jakl, Nick Hu, Nihil Shah, Hao Xu, Ieva Cepaite, Amin Karamlou, Amy Searle, Jules Hedges, Callum Reader, Benjamin Rodatz, Bruno Gavranovic, Swaraj Dash, (Razin Shaikh, Zanzi Mihejevs, Dylan Braithwaite, Joseph Grant), Joseph Martin, Paul Wilson, Cole Comfort, Matteo Capucci, Alex Rice, Calin Tataru, Simon Willerton, Ioannis Markakis, George Kate, Robert Furber, and Lukas Heidemann.
 </p>
@@ -586,7 +616,7 @@ please do not show up in person at the conference. Due to the need for physical 
 	be found on Google Maps. If you need a taxi, Uber operates in the city,
 	and Camcab is a traditional taxi firm which can be contacted on 01223 704704. There is a nice cycle path which is an ideal way to walk or cycle between the department and the city centre, illustrated on the map below.</p>
 
-<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d8224.006500137335!2d0.09795065920242622!3d52.20683376535952!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e2!4m5!1s0x47d8774a3f6e55cd%3A0xabf8227343e684c7!2sComputer%20Laboratory%2C%20University%20of%20Cambridge%2C%2015%20JJ%20Thomson%20Ave%2C%20Cambridge%20CB3%200FD!3m2!1d52.210891!2d0.0914855!4m3!3m2!1d52.2056348!2d0.1179634!5e0!3m2!1sen!2suk!4v1625820307063!5m2!1sen!2suk" width="1200" height="450" style="border:1;" allowfullscreen="" loading="lazy"></iframe>
+<iframe src="https://www.google.com/maps/embed?pb=!1m26!1m12!1m3!1d8224.006500137335!2d0.09795065920242622!3d52.20683376535952!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m11!3e2!4m5!1s0x47d8774a3f6e55cd%3A0xabf8227343e684c7!2sComputer%20Laboratory%2C%20University%20of%20Cambridge%2C%2015%20JJ%20Thomson%20Ave%2C%20Cambridge%20CB3%200FD!3m2!1d52.210891!2d0.0914855!4m3!3m2!1d52.2056348!2d0.1179634!5e0!3m2!1sen!2suk!4v1625820307063!5m2!1sen!2suk" width="100%" height="450" style="border:1;" allowfullscreen="" loading="lazy"></iframe>
 
 	<!--<p>Official conference accommodation will be available for priority booking by physical participants at a College of the university.
 		The deadline for booking this official accommodation is Monday 14 June. The booking code will only be made available to
@@ -712,7 +742,7 @@ prefer, and submissions may be moved from the Proceedings Track to the
 
 <h2>Sponsors</h2>
 
-<p id="sponsors">
+<div id="sponsors">
 	<center>
 <a target="blank" href="https://conexus.com/"><img style="height:70px; margin-bottom:20px; margin-top:20px" src="logos/conexus_trimmed.svg"/></a>
 <br>
@@ -722,7 +752,7 @@ prefer, and submissions may be moved from the Proceedings Track to the
 <br>
 <a target="blank" href="https://cambridgequantum.com/"><img style="height:100px; margin-bottom:20px" src="logos/cqc_trimmed.svg"/></a>
 </center>
-</p>
+</div>
 
 <h2>Programme Committee</h2>
 <ul>


### PR DESCRIPTION
Made a few changes so that the site renders better on mobile.
This one should preserve the overhanging header bars and only display the scrollbar when necessary.

* Top image now scales with the size of the screen when screen < 1920px
* Schedule now scrolls when not enough space to view (often when viewing portrait on phone screens)
* Conference image now scales with the screen
* Organiser images are all on one line when width > 1200px
* Sponsor images do not overhang on mobile
* Google map does not overhang on mobile

If you have any more comments I'll be happy to implement them!